### PR TITLE
Add compile-time configuration options to select the Z80 and the AY-3-8912 emulators.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,31 @@
 cmake_minimum_required(VERSION 3.13...${CMAKE_VERSION})
 project(Spectral LANGUAGES C CXX)
+
+set(	Spectral_AY38910
+	"floh" CACHE STRING
+	"Spectral: AY-3-8910 emulator to use.")
+
+set(	Spectral_Z80
+	"floh" CACHE STRING
+	"Spectral: Z80 emulator to use.")
+
 add_executable(Spectral src/zx.c src/sys_window.cc)
 target_compile_options(Spectral PRIVATE /MT /GL /GF /arch:AVX2)
 target_compile_definitions(Spectral PRIVATE main=WinMain $<$<CONFIG:Release>:FLAGS=FLAGS_REL>)
 target_link_options(Spectral PRIVATE /SUBSYSTEM:WINDOWS)
+
+if(Spectral_AY38910 STREQUAL ayumi)
+	target_compile_definitions(Spectral PRIVATE SPECTRAL_AY38910=SPECTRAL_AY38910_AYUMI)
+elseif(Spectral_AY38910 STREQUAL floh)
+	target_compile_definitions(Spectral PRIVATE SPECTRAL_AY38910=SPECTRAL_AY38910_FLOH)
+else()
+	message(FATAL_ERROR "Unknown AY-3-8910 emulator. Use `ayumi` or `floh`.")
+endif()
+
+if(Spectral_Z80 STREQUAL floh)
+	target_compile_definitions(Spectral PRIVATE SPECTRAL_Z80=SPECTRAL_Z80_FLOH)
+elseif(Spectral_Z80 STREQUAL redcode)
+	target_compile_definitions(Spectral PRIVATE SPECTRAL_Z80=SPECTRAL_Z80_REDCODE)
+else()
+	message(FATAL_ERROR "Unknown Z80 emulator. Use `floh` or `redcode`.")
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,9 @@
 cmake_minimum_required(VERSION 3.13...${CMAKE_VERSION})
 project(Spectral LANGUAGES C CXX)
 
-set(	Spectral_AY38910
+set(	Spectral_AY
 	"floh" CACHE STRING
-	"Spectral: AY-3-8910 emulator to use.")
+	"Spectral: AY-3-8912 emulator to use.")
 
 set(	Spectral_Z80
 	"floh" CACHE STRING
@@ -14,12 +14,12 @@ target_compile_options(Spectral PRIVATE /MT /GL /GF /arch:AVX2)
 target_compile_definitions(Spectral PRIVATE main=WinMain $<$<CONFIG:Release>:FLAGS=FLAGS_REL>)
 target_link_options(Spectral PRIVATE /SUBSYSTEM:WINDOWS)
 
-if(Spectral_AY38910 STREQUAL ayumi)
-	target_compile_definitions(Spectral PRIVATE SPECTRAL_AY38910=SPECTRAL_AY38910_AYUMI)
-elseif(Spectral_AY38910 STREQUAL floh)
-	target_compile_definitions(Spectral PRIVATE SPECTRAL_AY38910=SPECTRAL_AY38910_FLOH)
+if(Spectral_AY STREQUAL ayumi)
+	target_compile_definitions(Spectral PRIVATE SPECTRAL_AY=SPECTRAL_AY_AYUMI)
+elseif(Spectral_AY STREQUAL floh)
+	target_compile_definitions(Spectral PRIVATE SPECTRAL_AY=SPECTRAL_AY_FLOH)
 else()
-	message(FATAL_ERROR "Unknown AY-3-8910 emulator. Use `ayumi` or `floh`.")
+	message(FATAL_ERROR "Unknown AY-3-8912 emulator. Use `ayumi` or `floh`.")
 endif()
 
 if(Spectral_Z80 STREQUAL floh)

--- a/src/zx.h
+++ b/src/zx.h
@@ -1,8 +1,16 @@
 /* Project configuration macros */
-#define SPECTRAL_AY38910_AYUMI 0
-#define SPECTRAL_AY38910_FLOH  1
-#define SPECTRAL_Z80_FLOH      0
-#define SPECTRAL_Z80_REDCODE   1
+#define SPECTRAL_AY_AYUMI    0
+#define SPECTRAL_AY_FLOH     1
+#define SPECTRAL_Z80_FLOH    0
+#define SPECTRAL_Z80_REDCODE 1
+
+#ifndef SPECTRAL_AY
+    #define SPECTRAL_AY SPECTRAL_AY_FLOH
+#endif
+
+#ifndef SPECTRAL_Z80
+    #define SPECTRAL_Z80 SPECTRAL_Z80_FLOH
+#endif
 
 #define DEV       (1<< 0) // status bar, z80 disasm
 #define RF        (1<< 1)
@@ -51,7 +59,7 @@ const char* static_options() {
     #if FLAGS & FDC
     "+ FDC\n"
     #endif
-    #if SPECTRAL_AY38910 == SPECTRAL_AY38910_AYUMI
+    #if SPECTRAL_AY == SPECTRAL_AY_AYUMI
     "+ AYUMI\n"
     #endif
     #if FLAGS & FULLER
@@ -648,7 +656,7 @@ struct mouse mouse() {
 // ay
 void port_0xfffd(byte value) {
     ay_current_reg=(value&15);
-#if SPECTRAL_AY38910 != SPECTRAL_AY38910_AYUMI
+#if SPECTRAL_AY != SPECTRAL_AY_AYUMI
     // select ay-3-8912 register
     ay38910_iorq(&ay, AY38910_BDIR|AY38910_BC1|ay_current_reg<<16);
 #endif
@@ -656,7 +664,7 @@ void port_0xfffd(byte value) {
 void port_0xbffd(byte value) {
 //mic_on = 0;
     ay_registers[ay_current_reg]=value;
-#if SPECTRAL_AY38910 == SPECTRAL_AY38910_AYUMI
+#if SPECTRAL_AY == SPECTRAL_AY_AYUMI
     int *r = ay_registers;
     switch (ay_current_reg)
     {
@@ -856,7 +864,7 @@ void init() {
     bdesc.base_volume = BUZZ_VOLUME;
     beeper_init(&buzz, &bdesc);
 
-#if SPECTRAL_AY38910 == SPECTRAL_AY38910_AYUMI
+#if SPECTRAL_AY == SPECTRAL_AY_AYUMI
     const int is_ym = 1; // should be 0, but 1 sounds more Speccy to me somehow (?)
     const int eqp_stereo_on = 0;
     const double pan_modes[7][3] = { // pan modes, 7 stereo types
@@ -983,7 +991,7 @@ void sys_audio() {
 
     // tick the AY (half frequency)
     static float ay_sample = 0;
-#if SPECTRAL_AY38910 == SPECTRAL_AY38910_AYUMI
+#if SPECTRAL_AY == SPECTRAL_AY_AYUMI
     static byte even = 0; if( even == 0 || even == 0x80 ) {
         // update_ayumi_state(&ayumi, ay_registers);
         ay_sample = ayumi_render(&ayumi, ay_registers, 50.00 / AUDIO_FREQUENCY, 1); // frame_rate / audio_rate

--- a/src/zx.h
+++ b/src/zx.h
@@ -1,3 +1,9 @@
+/* Project configuration macros */
+#define SPECTRAL_AY38910_AYUMI 0
+#define SPECTRAL_AY38910_FLOH  1
+#define SPECTRAL_Z80_FLOH      0
+#define SPECTRAL_Z80_REDCODE   1
+
 #define DEV       (1<< 0) // status bar, z80 disasm
 #define RF        (1<< 1)
 #define CRT       (1<< 2)
@@ -45,7 +51,7 @@ const char* static_options() {
     #if FLAGS & FDC
     "+ FDC\n"
     #endif
-    #if FLAGS & AYUMI
+    #if SPECTRAL_AY38910 == SPECTRAL_AY38910_AYUMI
     "+ AYUMI\n"
     #endif
     #if FLAGS & FULLER
@@ -642,7 +648,7 @@ struct mouse mouse() {
 // ay
 void port_0xfffd(byte value) {
     ay_current_reg=(value&15);
-#if !(FLAGS & AYUMI)
+#if SPECTRAL_AY38910 != SPECTRAL_AY38910_AYUMI
     // select ay-3-8912 register
     ay38910_iorq(&ay, AY38910_BDIR|AY38910_BC1|ay_current_reg<<16);
 #endif
@@ -650,7 +656,7 @@ void port_0xfffd(byte value) {
 void port_0xbffd(byte value) {
 //mic_on = 0;
     ay_registers[ay_current_reg]=value;
-#if FLAGS & AYUMI
+#if SPECTRAL_AY38910 == SPECTRAL_AY38910_AYUMI
     int *r = ay_registers;
     switch (ay_current_reg)
     {
@@ -850,7 +856,7 @@ void init() {
     bdesc.base_volume = BUZZ_VOLUME;
     beeper_init(&buzz, &bdesc);
 
-#if FLAGS & AYUMI
+#if SPECTRAL_AY38910 == SPECTRAL_AY38910_AYUMI
     const int is_ym = 1; // should be 0, but 1 sounds more Speccy to me somehow (?)
     const int eqp_stereo_on = 0;
     const double pan_modes[7][3] = { // pan modes, 7 stereo types
@@ -977,7 +983,7 @@ void sys_audio() {
 
     // tick the AY (half frequency)
     static float ay_sample = 0;
-#if FLAGS & AYUMI
+#if SPECTRAL_AY38910 == SPECTRAL_AY38910_AYUMI
     static byte even = 0; if( even == 0 || even == 0x80 ) {
         // update_ayumi_state(&ayumi, ay_registers);
         ay_sample = ayumi_render(&ayumi, ay_registers, 50.00 / AUDIO_FREQUENCY, 1); // frame_rate / audio_rate


### PR DESCRIPTION
This PR adds CMake configuration options that set predefined macros intended to configure at compile time which emulators to use for the Z80 CPU and the AY PSG.